### PR TITLE
Investigate missing category edit success message

### DIFF
--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -80,7 +80,7 @@ class CategoryController extends Controller
     {
         $request->merge(['id' => $id]);
         $message = $this->categoryService->addEditCategory($request);
-        return redirect()->route('categories.index')->with('succcess_message', $message);
+        return redirect()->route('categories.index')->with('success_message', $message);
     }
 
     /**


### PR DESCRIPTION
Corrected typo in flash message key to display success message after editing a category.

---
<a href="https://cursor.com/background-agent?bcId=bc-535812ce-4dd9-4571-b302-4bc83284a7f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-535812ce-4dd9-4571-b302-4bc83284a7f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

